### PR TITLE
chore: migrate to reusable PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,71 +5,13 @@ on:
     tags: ["v*"]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: pip
-
-      - name: Install all packages in dev mode
-        run: |
-          pip install -e "packages/core[dev]"
-          for pkg in sandbox recorder reward hub trainer; do
-            pip install -e "packages/$pkg[dev]"
-          done
-
-      - name: Lint
-        run: pip install ruff && ruff check packages/ tests/
-
-      - name: Test
-        run: |
-          python -m pytest packages/core/tests/ -v
-          python -m pytest packages/sandbox/tests/ -v
-          python -m pytest packages/recorder/tests/ -v
-          python -m pytest packages/reward/tests/ -v
-          python -m pytest packages/hub/tests/ -v
-          python -m pytest packages/trainer/tests/ -v
-          python -m pytest tests/integration/ -v
-
   publish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - run: pip install build twine
-
-      - name: Build all packages
-        run: |
-          for pkg in core sandbox recorder reward hub trainer; do
-            echo "=== Building $pkg ==="
-            python -m build packages/$pkg/
-          done
-
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          for pkg in core sandbox recorder reward hub trainer; do
-            echo "=== Publishing $pkg ==="
-            twine upload packages/$pkg/dist/* --skip-existing
-          done
-
-  notify-crew:
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
-          repository: liuxiaotong/knowlyr-crew
-          event-type: knowlyr-gym-released
+    uses: liuxiaotong/knowlyr-workflows/.github/workflows/reusable-publish-pypi.yml@main
+    with:
+      build_tool: "setuptools"
+      python_version: "3.13"
+      run_tests: true
+      monorepo_packages: "packages/core,packages/sandbox,packages/recorder,packages/reward,packages/hub"
+    permissions:
+      id-token: write
+      contents: read


### PR DESCRIPTION
## Summary
- Replaces inline publish workflow with caller to `knowlyr-workflows/reusable-publish-pypi.yml`
- Monorepo mode: builds and publishes packages/core, sandbox, recorder, reward, hub
- Uses setuptools + Python 3.13 + trusted publisher, with tests enabled
- Part of TD-2026-004 Phase 1

## Test plan
- [ ] Next `v*` tag push triggers the reusable workflow correctly